### PR TITLE
Fix warning about unknown field in status.dat

### DIFF
--- a/bin/icli
+++ b/bin/icli
@@ -367,7 +367,7 @@ sub read_objects_line {
 				[
 					qw[
 					  timeperiod command contactgroup contact host service
-					  servicedependency
+					  servicedependency module
 					  ]
 				]
 			  )


### PR DESCRIPTION
Hi,

calling icli with current icinga yields a warning:
 Unknown field in /var/lib/icinga/status.dat: module

This commit adds the module entry to the list of ignored entrys. 
