### PR TITLE
Add hostdependency to the skipped objects

### DIFF
--- a/bin/icli
+++ b/bin/icli
@@ -379,7 +379,7 @@ sub read_objects_line {
 				[
 					qw[
 					  timeperiod command contactgroup contact host service
-					  servicedependency serviceescalation module
+					  servicedependency serviceescalation module hostdependency
 					  ]
 				]
 			  )


### PR DESCRIPTION
Hi,

I have some hostdependencies declared in my Nagios configuration.
Since icli does not know them, some messages are presented:
"Unknown field in /blub/bla/status.dat: hostdependency"
So I added "hostdependeny" to the ignored objects list.

Regards,

Philipp
