### PR TITLE
End commandline with a newline

### DIFF
--- a/bin/icli
+++ b/bin/icli
@@ -1195,7 +1195,7 @@ sub display_overview {
 }
 
 sub dispatch_command {
-	my $str = join( ';', @_ );
+	my $str = join( ';', @_ ) . "\n";
 
 	open( my $cmd_fh, '>', $rw_file )
 	  or die( "Failed to open icinga command file ($rw_file): $!\n"


### PR DESCRIPTION
Due to a [recent change](https://github.com/Icinga/icinga2/commit/0a6505ce2d778d46863345ad7b457cbe911a3176#diff-41f5f9b62fd89e63b82e66bbe76c0e73R121) in Icinga, commands passed through the external command listener are read by _readline_ so that's mean they have to be ended by a newline.