### PR TITLE
Fix acknowledging outages

### DIFF
--- a/bin/icli
+++ b/bin/icli
@@ -1291,7 +1291,7 @@ sub action_on_service {
 				time() );
 			say "Scheduled forced check of '$service' on '$host'";
 		}
-		when ('Acknowledge') {
+		when ('acknowledge') {
 			dispatch_command( 'ACKNOWLEDGE_SVC_PROBLEM', $host, $service, 2, 1,
 				1, 'cli', $action_args[0] );
 			say "Acknowledged $host/$service: $action_args[0]";


### PR DESCRIPTION
The internal command name is lower cased like the other commands.
Fixes "Cannot run action 'acknowledge'" errors.